### PR TITLE
docs: actualizar esquema de agentes (Jules→Gemini→Codex)

### DIFF
--- a/docs/agents-global.md
+++ b/docs/agents-global.md
@@ -1,7 +1,7 @@
-AGENTS-GLOBAL.md — Política de Directorio (Gemini)
+AGENTS-GLOBAL.md — Política de Directorio (Esquema Actualizado)
 1) Regla general
 
-Gemini CLI y Jules (Labs) no deben operar fuera del directorio del repo donde se ejecutan.
+Jules, Gemini y Codex no deben operar fuera del directorio del repo donde se ejecutan.
 
 2) Cómo trabajamos multi-repo
 
@@ -9,7 +9,7 @@ Cambios cross-repo → vía handoff (issue con checklist + enlace a PR/artefacto
 
 Artefactos transferibles: openapi.yaml, SDK-PLAN.md, guías .md, zips con dist del SDK.
 
-Los cambios de código en otros repos los ejecutan Copilot (autocompletado/ediciones locales) o Blackbox (solo si es complejo y justifica créditos).
+Los cambios de código en otros repos se ejecutan mediante handoff. Herramientas adicionales (Copilot/Blackbox/Qwen/Warp) solo si hay bloqueo o se requiere análisis profundo.
 
 3) Ramas y PR
 
@@ -21,28 +21,13 @@ Prohibido tocar main y CI fuera del repo abierto.
 
 ```mermaid
 flowchart LR
-  subgraph Repo_API
-    A[Gemini CLI\nAPI-Contract] -- openapi.yaml/ERRORS.md --> PR_API[PR a dev]
-  end
-
-  subgraph Repo_Cliente
-    C[Copilot\nFront Cliente] <-- handoff: openapi.yaml --> Issue_C[Issue: Consumir contrato]
-  end
-
-  subgraph Repo_Tienda
-    T[Copilot\nFront Tienda] <-- handoff: openapi.yaml --> Issue_T[Issue: Consumir contrato]
-  end
-
   subgraph Repo_Repartidor
-    R[Copilot\nFront Repartidor] <-- handoff: openapi.yaml --> Issue_R[Issue: Consumir contrato]
+    J[Jules\nImplementación Front] --> G[Gemini\nQA/Pulido]
+    G --> Cx[Codex\nÚltimo filtro]
+    Cx --> PR_Repartidor[PR a dev]
   end
 
   subgraph Orquestacion
-    J[Jules (Labs)] -- coordina docs\n(Repo actual) --> PR_DOCS[PR docs a dev]
+    H[Handoffs cross-repo] --- Note[Blackbox/Qwen/Warp\nsolo si hay bloqueo]
   end
-
-  PR_API --> HandoffAPI[Handoff Notes]
-  HandoffAPI --> Issue_C
-  HandoffAPI --> Issue_T
-  HandoffAPI --> Issue_R
 ```


### PR DESCRIPTION
Actualiza agents-global.md al nuevo flujo: Jules implementa, Gemini QA/pulido, Codex último filtro y PR. Uso de Blackbox/Qwen/Warp solo ante bloqueos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed and updated the AGENTS-GLOBAL policy document to reflect the current schema.
  * Clarified multi-repo workflow with emphasis on handoffs and what artifacts can be transferred; outlined when auxiliary tools may be used.
  * Added explicit branching/PR guidance: one PR per repo, target dev, use feat/* or docs/*; keep main and CI untouched outside the active repo.
  * Revamped Mermaid diagram to reflect the new cross-repo handoff flow and role sequence.
  * Applied minor formatting and text refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->