### PR TITLE
feat: connect auth screens to API

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,69 @@
+import http from 'node:http';
+
+const users = [];
+
+const server = http.createServer((req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const sendJson = (status, data) => {
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(data));
+  };
+
+  if (req.method === 'POST' && req.url === '/api/v1/auth/register') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body || '{}');
+        const { email, password } = data;
+        if (!email) {
+          sendJson(400, { message: 'Email required' });
+          return;
+        }
+        if (users.find(u => u.email === email)) {
+          sendJson(409, { message: 'User already exists' });
+          return;
+        }
+        const token = `token-${Date.now()}`;
+        users.push({ email, password, token });
+        sendJson(200, { token });
+      } catch {
+        sendJson(400, { message: 'Invalid JSON' });
+      }
+    });
+  } else if (req.method === 'POST' && req.url === '/api/v1/auth/login') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body || '{}');
+        const { email, password } = data;
+        const user = users.find(u => u.email === email && u.password === password);
+        if (!user) {
+          sendJson(401, { message: 'Invalid credentials' });
+          return;
+        }
+        sendJson(200, { token: user.token });
+      } catch {
+        sendJson(400, { message: 'Invalid JSON' });
+      }
+    });
+  } else {
+    sendJson(404, { message: 'Not found' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`API server listening on http://localhost:${PORT}`);
+});
+

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -8,28 +8,32 @@ import { useStore } from '@/store/useStore';
 import { useToast } from '@/hooks/use-toast';
 import { Loader2 } from 'lucide-react';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
 const loginUser = async (credentials: any) => {
-  // SIMULATED API CALL
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      if (credentials.email === 'test@yega.dev' && credentials.password === 'password') {
-        resolve({ token: 'fake-jwt-token' });
-      } else {
-        reject(new Error('Invalid credentials'));
-      }
-    }, 1000);
+  const response = await fetch(`${API_BASE_URL}/api/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(credentials),
   });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.message || 'Login failed');
+  }
+  return data;
 };
 
 const registerUser = async (userInfo: any) => {
-  // SIMULATED API CALL
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({ token: 'fake-jwt-token-new-user' });
-    }, 1000);
+  const response = await fetch(`${API_BASE_URL}/api/v1/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(userInfo),
   });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.message || 'Registration failed');
+  }
+  return data;
 };
 
 

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -30,14 +30,22 @@ interface AppState {
   };
 }
 
+const token = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
+
 export const useStore = create<AppState>((set) => ({
-  isAuthenticated: false, // Default to false
-  authToken: null,
-  currentView: 'auth',
+  isAuthenticated: !!token,
+  authToken: token,
+  currentView: token ? 'dashboard' : 'auth',
   selectedOrder: null,
   actions: {
-    login: (token) => set({ isAuthenticated: true, authToken: token, currentView: 'dashboard' }),
-    logout: () => set({ isAuthenticated: false, authToken: null, currentView: 'auth' }),
+    login: (token) => {
+      localStorage.setItem('authToken', token);
+      set({ isAuthenticated: true, authToken: token, currentView: 'dashboard' });
+    },
+    logout: () => {
+      localStorage.removeItem('authToken');
+      set({ isAuthenticated: false, authToken: null, currentView: 'auth' });
+    },
     setView: (view) => set({ currentView: view }),
     selectOrder: (order) => set({ selectedOrder: order, currentView: 'delivery' }),
     clearOrder: () => set({ selectedOrder: null, currentView: 'dashboard' }),


### PR DESCRIPTION
## Summary
- connect auth screens to backend endpoints
- persist auth token in zustand store
- provide simple Node HTTP server with login/register endpoints

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 7 errors, 7 warnings)*
- `curl -s -X POST http://localhost:3000/api/v1/auth/register -H 'Content-Type: application/json' -d '{"email":"test@example.com","password":"password"}'`
- `curl -s -X POST http://localhost:3000/api/v1/auth/login -H 'Content-Type: application/json' -d '{"email":"test@example.com","password":"password"}'`


------
https://chatgpt.com/codex/tasks/task_e_68a5e3059b708328bd769dbf0c692b51